### PR TITLE
Added synchronous call to pobox to provide feedback if the buffer is full

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ And keep going on and on and on.
   plenty of users asked for before. Tricking the filter function to
   forward the message (`self() ! Msg`) while dropping it will allow
   to do selective receives on bounded mailboxes.
+- When using `post_sync/3` keep in mind that full doesn't mean your message
+  will be dropped unless you are using the `keep_old` buffer type or
+  a custom buffer that behaves the same way as `keep_old`.
 
 ## Contributing
 


### PR DESCRIPTION
If can be useful to know the buffer is full with keep_old style buffers. It enables fail fast scenarios.

```
eric@eric-desktop:~/dev/pobox$ rebar3 shell
===> Verifying dependencies...
===> Compiling pobox
Erlang/OTP 20 [erts-9.3] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:0] [hipe] [kernel-poll:false]

Eshell V9.3  (abort with ^G)
1> {ok, Box} = pobox:start_link(self(), 3, keep_old).
{ok,<0.103.0>}
2> pobox:post_sync(Box, 1, 5000).   
ok
3> pobox:post_sync(Box, 2, 5000).
ok
4> pobox:post_sync(Box, 3, 5000).
ok
5> pobox:post_sync(Box, 4, 5000).
full
```