### PR TITLE
Added ets style heir, heir data and give_away feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: erlang
+otp_release:
+  - 21.1
+  - 20.3
+  - 19.3
+#  - 18.3   # NOTE: We know gen_statem requires Erlang 19+
+#  - 17.3
+#  - R16B03
+#  - R15B03
+script:
+  - rebar3 ct --readable=false

--- a/test/pobox_give_away_SUITE.erl
+++ b/test/pobox_give_away_SUITE.erl
@@ -1,0 +1,134 @@
+-module(pobox_give_away_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+all() -> [
+  owner_gives_away_ownership,
+  owner_gives_away_ownership_with_data,
+  owner_gives_away_ownership_to_dead_process,
+  foreign_process_tries_to_gives_away_ownership,
+  give_away_does_not_change_heir,
+  owner_gives_away_ownership_when_in_notify,
+  owner_gives_away_ownership_when_in_active
+].
+
+owner_gives_away_ownership(_Config) ->
+    {ok, Box} = pobox:start_link(#{size => 10}),
+    Self = self(),
+    H = erlang:spawn_link(fun F () -> receive X -> Self ! X end, F() end),
+    ?assert(pobox:give_away(Box, H, 5000)),
+    ?assertMatch(
+        {pobox_transfer, Box, Self, undefined, give_away},
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ).
+
+owner_gives_away_ownership_with_data(_Config) ->
+    {ok, Box} = pobox:start_link([{size, 10}]),
+    Self = self(),
+    H = erlang:spawn_link(fun F () -> receive X -> Self ! X end, F() end),
+    Ref = make_ref(),
+    ?assert(pobox:give_away(Box, H, Ref, 5000)),
+    ?assertMatch(
+      {pobox_transfer, Box, Self, Ref, give_away},
+      receive
+          Res -> Res
+      after
+          5000 -> timeout
+      end
+    ).
+
+owner_gives_away_ownership_to_dead_process(_Config) ->
+    {ok, Box} = pobox:start_link([{size, 10}]),
+    Self = self(),
+    H = erlang:spawn(fun F () -> receive X -> Self ! X end, F() end),
+    erlang:exit(H, kill),
+    timer:sleep(100),
+    ?assertNot(pobox:give_away(Box, H, 5000)),
+    ?assert(receive
+         _ -> false
+    after
+        100 -> true
+    end).
+
+
+foreign_process_tries_to_gives_away_ownership(_Config) ->
+    {ok, Box} = pobox:start_link([{size, 10}]),
+    Self = self(),
+    erlang:spawn_link(fun() -> Self ! pobox:give_away(Box, self(), 5000) end),
+    ?assertNot(receive Res -> Res end).
+
+give_away_does_not_change_heir(_Config) ->
+    Self = self(),
+    {ok, Box} = pobox:start_link([{heir, Self}, {heir_data, first}, {size, 10}]),
+    H = erlang:spawn(fun() -> receive X -> Self ! X end, throw("crash") end),
+    ?assert(pobox:give_away(Box, H, second, 5000)),
+    ?assertMatch(
+      {pobox_transfer, Box, Self, second, give_away},
+      receive
+          Res -> Res
+      after
+          5000 -> timeout
+      end
+    ),
+    ?assertMatch(
+        {pobox_transfer, Box, H, first, Reason} when Reason =/= give_away,
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ).
+
+owner_gives_away_ownership_when_in_notify(_Config) ->
+    {ok, Box} = pobox:start_link([{size, 10}]),
+    ok = pobox:notify(Box),
+    Self = self(),
+    H = erlang:spawn_link(fun F () -> receive X -> Self ! X end, F() end),
+    ?assertMatch(notify, element(1, sys:get_state(Box))),
+    ?assert(pobox:give_away(Box, H, 5000)),
+    ?assertMatch(
+        {pobox_transfer, Box, Self, undefined, give_away},
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ),
+    ?assert(
+        receive
+            _ -> false
+        after
+            100 -> true
+        end
+    ),
+    ?assertMatch(passive, element(1, sys:get_state(Box))).
+
+owner_gives_away_ownership_when_in_active(_Config) ->
+    {ok, Box} = pobox:start_link([{size, 10}]),
+    ok = pobox:active(Box, fun(_Msg, _) -> skip end, nostate),
+    Self = self(),
+    H = erlang:spawn_link(fun F () -> receive X -> Self ! X end, F() end),
+    ?assertMatch(active_s, element(1, sys:get_state(Box))),
+    ?assert(pobox:give_away(Box, H, 5000)),
+    ?assertMatch(
+        {pobox_transfer, Box, Self, undefined, give_away},
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ),
+    ?assert(
+        receive
+            _ -> false
+        after
+            100 -> true
+        end
+    ),
+    ?assertMatch(passive, element(1, sys:get_state(Box))).

--- a/test/pobox_heir_SUITE.erl
+++ b/test/pobox_heir_SUITE.erl
@@ -1,0 +1,217 @@
+-module(pobox_heir_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+all() -> [
+    with_local_registered_name_owner,
+    with_global_registered_name_owner,
+    with_global_registered_name_heir,
+    with_via_registered_name_owner,
+    owner_crashes_heir_takes_over,
+    heir_dies_then_owner_dies,
+    goes_to_passive_mode_when_in_notify,
+    goes_to_passive_mode_when_in_active
+].
+
+
+with_local_registered_name_owner(_Config) ->
+    Self = self(),
+    Ref = make_ref(),
+    PreviousOwnerPid = erlang:spawn(fun() ->
+        {ok, Box} = pobox:start_link({local, ?MODULE}, #{heir => Self, heir_data => Ref, size => 10}),
+        Self ! Box,
+        throw("crash")
+    end),
+    Box = receive
+        BoxPid when is_pid(BoxPid) -> BoxPid
+    after
+        100 -> false
+    end,
+    ?assertMatch(
+        {pobox_transfer, Box, PreviousOwnerPid, Ref, _},
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ).
+
+
+with_global_registered_name_owner(_Config) ->
+    Self = self(),
+    Ref = make_ref(),
+    PreviousOwnerPid = erlang:spawn(fun() ->
+        {ok, Box} = pobox:start_link({global, ?MODULE}, [{heir, Self}, {heir_data, Ref}, {size, 10}]),
+        Self ! Box,
+        throw("crash")
+    end),
+    Box = receive
+        BoxPid when is_pid(BoxPid) -> BoxPid
+    after
+        100 -> false
+    end,
+    ?assertMatch(
+        {pobox_transfer, Box, PreviousOwnerPid, Ref, _},
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ).
+
+
+with_global_registered_name_heir(_Config) ->
+    Self = self(),
+    Ref = make_ref(),
+    yes = global:register_name(my_global_name, self()),
+    PreviousOwnerPid = erlang:spawn(fun() ->
+        {ok, Box} = pobox:start_link([{heir, {global, my_global_name}}, {heir_data, Ref}, {size, 10}]),
+        Self ! Box,
+        throw("crash")
+    end),
+    Box = receive
+        BoxPid when is_pid(BoxPid) -> BoxPid
+    after
+        100 -> false
+    end,
+    ?assertMatch(
+        {pobox_transfer, Box, PreviousOwnerPid, Ref, _},
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ).
+
+with_via_registered_name_owner(_Config) ->
+    Self = self(),
+    Ref = make_ref(),
+    PreviousOwnerPid = erlang:spawn(fun() ->
+        {ok, Box} = pobox:start_link({via, global, fake_name}, [{heir, Self}, {heir_data, Ref}, {size, 10}]),
+        Self ! Box,
+        throw("crash")
+    end),
+    Box = receive
+        BoxPid when is_pid(BoxPid) -> BoxPid
+    after
+        100 -> false
+    end,
+    ?assertMatch(
+        {pobox_transfer, Box, PreviousOwnerPid, Ref, _},
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ).
+
+
+owner_crashes_heir_takes_over(_Config) ->
+    Self = self(),
+    Ref = make_ref(),
+    PreviousOwnerPid = erlang:spawn(fun() ->
+        {ok, Box} = pobox:start_link([{heir, Self}, {heir_data, Ref}, {size, 10}]),
+        Self ! Box,
+        throw("crash")
+    end),
+    Box = receive
+        BoxPid when is_pid(BoxPid) -> BoxPid
+    after
+        100 -> false
+    end,
+    ?assertMatch(
+        {pobox_transfer, Box, PreviousOwnerPid, Ref, _},
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ).
+
+heir_dies_then_owner_dies(_Config) ->
+    Self = self(),
+    Dest = erlang:spawn_link(fun() -> receive _ -> Self ! continue end end),
+    {ok, Box} = pobox:start_link([{heir, Self}, {heir_data, heir_data}, {size, 10}]),
+    ?assert(pobox:give_away(Box, Dest, dest_data, 500)),
+    ?assertMatch(continue, receive
+      Res -> Res
+    after
+        5000 -> timeout
+    end),
+    ?assertMatch(
+      {pobox_transfer, Box, Dest, heir_data, Reason} when Reason =/= give_away,
+      receive
+          Res -> Res
+      after
+          5000 -> timeout
+      end
+    ).
+
+goes_to_passive_mode_when_in_notify(_Config) ->
+    Self = self(),
+    Ref = make_ref(),
+    PreviousOwnerPid = erlang:spawn(fun() ->
+        {ok, Box} = pobox:start_link(#{heir => Self, heir_data => Ref, size => 10}),
+        ok = pobox:notify(Box),
+        Self ! Box,
+        throw("crash")
+    end),
+    Box = receive
+        BoxPid when is_pid(BoxPid) -> BoxPid
+    after
+        100 -> false
+    end,
+    ?assertMatch(
+        {pobox_transfer, Box, PreviousOwnerPid, Ref, _},
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ),
+    ?assert(
+        receive
+            _ -> false
+        after
+            100 -> true
+        end
+    ),
+    ?assertMatch(passive, element(1, sys:get_state(Box))).
+
+goes_to_passive_mode_when_in_active(_Config) ->
+    Self = self(),
+    Ref = make_ref(),
+    PreviousOwnerPid = erlang:spawn(fun() ->
+        {ok, Box} = pobox:start_link([{heir, Self}, {heir_data, Ref}, {size, 10}]),
+        ok = pobox:active(Box, fun(_Msg, _) -> skip end, nostate),
+        Self ! Box,
+        timer:sleep(100),
+        throw("crash")
+    end),
+    Box = receive
+        BoxPid when is_pid(BoxPid) -> BoxPid
+    after
+        100 -> false
+    end,
+    ?assertMatch(active_s, element(1, sys:get_state(Box))),
+    ?assertMatch(
+        {pobox_transfer, Box, PreviousOwnerPid, Ref, _},
+        receive
+            Res -> Res
+        after
+            5000 -> timeout
+        end
+    ),
+    ?assert(
+        receive
+            _ -> false
+        after
+            100 -> true
+        end
+    ),
+    ?assertMatch(passive, element(1, sys:get_state(Box))).
+
+
+


### PR DESCRIPTION
Details:

- Improved support for process registries (local, global, via)
- Test suites for heir and give_away functionality
- Applied DRY principle to guards (used macros for this purpose)
- New map syntax for start_link and proplist options
- Change init arguments to record instead of tuple (it was too long)
- Added travis continuous integration with tests for Erlang 19.3 to 21.1
- Updated README.md

